### PR TITLE
RuboCop Install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'omniauth-google-oauth2'
 gem 'omniauth-rails_csrf_protection'
 
 # RuboCop
+gem 'rubocop', require: false
 gem 'rubocop-rails', require: false
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,6 +294,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.1)
+  rubocop
   rubocop-rails
   sass-rails (>= 6)
   selenium-webdriver


### PR DESCRIPTION
Added rubocop and  rubocop-rails for development to lint code for better coding practices and to follow the community-driven ruby style guide when coding with Ruby.